### PR TITLE
docs: add missing libportaudio2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In development. Behavior may change.
 ## Requirements
 - Linux with libinput
 - Python 3
+- PortAudio (Debian/Ubuntu: `sudo apt install libportaudio2`)
 - User must be in `input` group (`sudo usermod -a -G input $USER`)
 - Python packages: numpy, sounddevice (automatically installing with install.sh)
 


### PR DESCRIPTION
Tested on Ubuntu 24.04 (X11). I encountered a crash because `libportaudio2` was missing. This PR adds the missing dependency to the Requirements section to prevent `OSError: PortAudio library not found` for future users.